### PR TITLE
Correctly fetch port config when HWSKU mismatch between config gen an…

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -170,9 +170,11 @@ def get_fabric_port_config(hwsku=None, platform=None, fabric_port_config_file=No
 
 def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_config_file=None, asic_name=None):
     config_db = db_connect_configdb(asic_name)
-    # If available, Read from CONFIG DB first
-    if config_db is not None and port_config_file is None:
 
+    config_db_hwsku = device_info.get_hwsku()
+
+    # If available, Read from CONFIG DB first
+    if config_db is not None and port_config_file is None and (hwsku is None or config_db_hwsku == hwsku):
         port_data = config_db.get_table("PORT")
         if bool(port_data):
             ports = ast.literal_eval(json.dumps(port_data))

--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -170,9 +170,8 @@ def get_fabric_port_config(hwsku=None, platform=None, fabric_port_config_file=No
 
 def get_port_config(hwsku=None, platform=None, port_config_file=None, hwsku_config_file=None, asic_name=None):
     config_db = db_connect_configdb(asic_name)
-
-    config_db_hwsku = device_info.get_hwsku()
-
+    
+    config_db_hwsku = device_info.get_localhost_info('hwsku', config_db=config_db)
     # If available, Read from CONFIG DB first
     if config_db is not None and port_config_file is None and (hwsku is None or config_db_hwsku == hwsku):
         port_data = config_db.get_table("PORT")

--- a/src/sonic-config-engine/tests/mock_tables/asic0/config_db.json
+++ b/src/sonic-config-engine/tests/mock_tables/asic0/config_db.json
@@ -94,5 +94,8 @@
         "role": "Int",
         "speed": "40000",
         "asic_port_name": "Eth7-ASIC0"
+    },
+    "DEVICE_METADATA|localhost": {
+        "hwsku" : "multi-npu-asic"
     }
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Incorrect golden config was being generated for non-default SKUs when using minigraph. This issue occurred because sonic-cfggen was reading port configuration from the config DB, even when the hardware SKU in the config DB differed. Incorrect ports and port_alias_map data from config db was causing the issue.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modified the logic to ensure that port configuration is fetched from the config DB only when the hardware SKU in the config DB matches the hardware SKU for which sonic-cfggen is generating the config.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Generated golden configurations for non-default SKUs and confirmed that the output was correct.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

